### PR TITLE
Add Flask energy management tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+energy.db
+instance/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Energy Management App
+
+Simple Flask application for managing energy meter readings and generating rebilling invoices.
+
+## Features
+- Manage meters with nickname, type (electricity, gas, water) and tenant to bill.
+- Enter readings for a selected month and energy type.
+- Edit previously entered readings.
+- Generate invoice table showing usage difference from previous month.
+
+## Running
+```bash
+pip install -r requirements.txt
+python3 -m flask --app app.py run
+```
+Then open `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,101 @@
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///energy.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+class Meter(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    nickname = db.Column(db.String(80), nullable=False)
+    type = db.Column(db.String(20), nullable=False)
+    tenant = db.Column(db.String(80), nullable=False)
+
+class Reading(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    meter_id = db.Column(db.Integer, db.ForeignKey('meter.id'), nullable=False)
+    month = db.Column(db.String(7), nullable=False)  # YYYY-MM
+    value = db.Column(db.Float, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    meter = db.relationship('Meter', backref=db.backref('readings', lazy=True))
+
+with app.app_context():
+    db.create_all()
+
+@app.route('/')
+def index():
+    return redirect(url_for('meters'))
+
+@app.route('/meters', methods=['GET', 'POST'])
+def meters():
+    if request.method == 'POST':
+        nickname = request.form['nickname']
+        type_ = request.form['type']
+        tenant = request.form['tenant']
+        meter = Meter(nickname=nickname, type=type_, tenant=tenant)
+        db.session.add(meter)
+        db.session.commit()
+        return redirect(url_for('meters'))
+
+    meters = Meter.query.all()
+    return render_template('meters.html', meters=meters)
+
+@app.route('/meters/<int:meter_id>/edit', methods=['GET', 'POST'])
+def edit_meter(meter_id):
+    meter = Meter.query.get_or_404(meter_id)
+    if request.method == 'POST':
+        meter.nickname = request.form['nickname']
+        meter.type = request.form['type']
+        meter.tenant = request.form['tenant']
+        db.session.commit()
+        return redirect(url_for('meters'))
+    return render_template('edit_meter.html', meter=meter)
+
+@app.route('/readings', methods=['GET', 'POST'])
+def readings():
+    month = request.args.get('month') or datetime.utcnow().strftime('%Y-%m')
+    type_ = request.args.get('type') or 'electricity'
+    meters = Meter.query.filter_by(type=type_).all()
+    existing = {r.meter_id: r.value for r in Reading.query.filter_by(month=month).all()}
+    if request.method == 'POST':
+        for meter in meters:
+            field = f'reading_{meter.id}'
+            if field in request.form and request.form[field]:
+                value = float(request.form[field])
+                reading = Reading.query.filter_by(meter_id=meter.id, month=month).first()
+                if reading:
+                    reading.value = value
+                else:
+                    reading = Reading(meter_id=meter.id, month=month, value=value)
+                    db.session.add(reading)
+        db.session.commit()
+        return redirect(url_for('readings', month=month, type=type_))
+    return render_template('readings.html', meters=meters, month=month, type=type_, readings=existing)
+
+@app.route('/invoices')
+def invoices():
+    month = request.args.get('month') or datetime.utcnow().strftime('%Y-%m')
+    type_ = request.args.get('type') or 'electricity'
+    invoices = []
+    meters = Meter.query.filter_by(type=type_).all()
+    for meter in meters:
+        current = Reading.query.filter_by(meter_id=meter.id, month=month).first()
+        last = Reading.query.filter(Reading.meter_id==meter.id, Reading.month < month).order_by(Reading.month.desc()).first()
+        if current:
+            last_value = last.value if last else 0
+            diff = current.value - last_value
+            invoices.append({
+                'tenant': meter.tenant,
+                'nickname': meter.nickname,
+                'last': last_value,
+                'current': current.value,
+                'diff': diff
+            })
+    return render_template('invoices.html', invoices=invoices, month=month, type=type_)
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Energy Management</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <nav>
+        <a href="/meters">Meters</a> |
+        <a href="/readings">Enter Readings</a> |
+        <a href="/invoices">Invoices</a>
+    </nav>
+    <hr>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/edit_meter.html
+++ b/templates/edit_meter.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Edit Meter</h2>
+<form method="post">
+    <input type="text" name="nickname" value="{{ meter.nickname }}" required>
+    <select name="type">
+        <option value="electricity" {% if meter.type=='electricity' %}selected{% endif %}>Electricity</option>
+        <option value="gas" {% if meter.type=='gas' %}selected{% endif %}>Gas</option>
+        <option value="water" {% if meter.type=='water' %}selected{% endif %}>Water</option>
+    </select>
+    <input type="text" name="tenant" value="{{ meter.tenant }}" required>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/invoices.html
+++ b/templates/invoices.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Invoices for {{ month }} ({{ type }})</h2>
+<table border="1">
+<tr><th>Tenant</th><th>Meter</th><th>Last Reading</th><th>Current Reading</th><th>Difference</th></tr>
+{% for inv in invoices %}
+<tr>
+<td>{{ inv.tenant }}</td>
+<td>{{ inv.nickname }}</td>
+<td>{{ inv.last }}</td>
+<td>{{ inv.current }}</td>
+<td>{{ inv.diff }}</td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/meters.html
+++ b/templates/meters.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Meters</h2>
+<form method="post" action="/meters">
+    <input type="text" name="nickname" placeholder="Nickname" required>
+    <select name="type">
+        <option value="electricity">Electricity</option>
+        <option value="gas">Gas</option>
+        <option value="water">Water</option>
+    </select>
+    <input type="text" name="tenant" placeholder="Tenant" required>
+    <button type="submit">Add Meter</button>
+</form>
+<table border="1">
+<tr><th>ID</th><th>Nickname</th><th>Type</th><th>Tenant</th><th>Actions</th></tr>
+{% for m in meters %}
+<tr>
+<td>{{ m.id }}</td>
+<td>{{ m.nickname }}</td>
+<td>{{ m.type }}</td>
+<td>{{ m.tenant }}</td>
+<td><a href="/meters/{{ m.id }}/edit">Edit</a></td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/readings.html
+++ b/templates/readings.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Enter Readings for {{ month }} ({{ type }})</h2>
+<form method="post">
+<table border="1">
+<tr><th>Nickname</th><th>Current State</th></tr>
+{% for meter in meters %}
+<tr>
+<td>{{ meter.nickname }}</td>
+<td><input type="number" step="0.01" name="reading_{{ meter.id }}" value="{{ readings[meter.id] if readings and meter.id in readings else '' }}"></td>
+</tr>
+{% endfor %}
+</table>
+<button type="submit">Save</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add basic Flask app with SQLAlchemy models
- create pages to manage meters, enter readings and view invoices
- document usage in README
- ignore database and cache files

## Testing
- `pip install -r requirements.txt`
- `python3 -m py_compile app.py`
- `python3 -m flask --app app.py routes`
- `python3 -m flask --app app.py run -p 5001` *(manual smoke test)*


------
https://chatgpt.com/codex/tasks/task_e_68483a562f948333b52b8bf0250b2271